### PR TITLE
Relaxed version requirements in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 paegan>=0.9.9
 OWSLib>=0.8-dev
 requests
-Fiona==0.16.1
-beautifulsoup4==4.2.1
+Fiona>=0.16.1
+beautifulsoup4>=4.2.1
 lxml>=3.2.0


### PR DESCRIPTION
Now change is based on an up-to-date clone freshly pulled from asascience-open/pyoos
