### PR TITLE
Improve robustness of variable/attribute detection

### DIFF
--- a/pyoos/parsers/ioos/describe_sensor.py
+++ b/pyoos/parsers/ioos/describe_sensor.py
@@ -1,46 +1,32 @@
 from pyoos.utils.etree import etree
 from owslib.namespaces import Namespaces
 from owslib.util import testXMLValue
+import warnings
 
 ns = Namespaces()
-
+SML_NS = ns.get_versioned_namespace('sml', '1.0.1')
+SWE_NS = [ns.get_versioned_namespace('swe', '1.0.1')]
 
 class IoosDescribeSensor(object):
+
     def __new__(cls, element):
         if isinstance(element, str):
             root = etree.fromstring(element)
         else:
             root = element
 
+        sml_str = ".//{{{0}}}identifier/{{{0}}}Term[@definition='http://mmisw.org/ont/ioos/definition/%s']".format(SML_NS)
+
         if hasattr(root, 'getroot'):
             root = root.getroot()
 
-        SWE_NS = [ns.get_versioned_namespace('swe', '1.0.1')]
-        version = None
-        for g in SWE_NS:
-            try:
-                version = testXMLValue(root.find(".//{%s}field[@name='ioosTemplateVersion']/{%s}Text/{%s}value" % (g, g, g)))
-                break
-            except:
-                raise
-
-        if version == "1.0":
-            SML_NS = ns.get_versioned_namespace('sml', '1.0.1')
-            try:
-                assert testXMLValue(root.find(".//{%s}identifier[@name='networkID']/{%s}Term[@definition='http://mmisw.org/ont/ioos/definition/networkID']/{%s}value" % (SML_NS, SML_NS, SML_NS)))
-                from pyoos.parsers.ioos.one.describe_sensor import NetworkDS
-                return super(IoosDescribeSensor, cls).__new__(NetworkDS)
-            except AssertionError:
-                try:
-                    assert testXMLValue(root.find(".//{%s}identifier[@name='stationID']/{%s}Term[@definition='http://mmisw.org/ont/ioos/definition/stationID']/{%s}value" % (SML_NS, SML_NS, SML_NS)))
-                    from pyoos.parsers.ioos.one.describe_sensor import StationDS
-                    return super(IoosDescribeSensor, cls).__new__(StationDS)
-                except AssertionError:
-                    try:
-                        assert testXMLValue(root.find(".//{%s}identifier[@name='sensorID']/{%s}Term[@definition='http://mmisw.org/ont/ioos/definition/sensorID']/{%s}value" % (SML_NS, SML_NS, SML_NS)))
-                        from pyoos.parsers.ioos.one.describe_sensor import SensorDS
-                        return super(IoosDescribeSensor, cls).__new__(SensorDS)
-                    except AssertionError:
-                        raise ValueError("Could not determine if this was a Network, Station, or Sensor SensorML document")
-        else:
-            raise ValueError("Unsupported IOOS version (%s).  Supported: [1.0]" % version)
+        # circular dependencies are bad. consider a reorganization
+        # find the the proper type for the DescribeSensor
+        from pyoos.parsers.ioos.one.describe_sensor import (NetworkDS,
+                                                            StationDS, SensorDS)
+        for ds_type, constructor in [('networkID', NetworkDS), ('stationID', StationDS), ('sensorID', SensorDS)]:
+            if root.find(sml_str % ds_type) is not None:
+                return super(IoosDescribeSensor, cls).__new__(constructor)
+        # if we don't find the proper request, try to use DescribeSensor
+        from pyoos.parsers.ioos.one.describe_sensor import GenericSensor
+        return super(IoosDescribeSensor, cls).__new__(GenericSensor)

--- a/pyoos/parsers/ioos/describe_sensor.py
+++ b/pyoos/parsers/ioos/describe_sensor.py
@@ -1,7 +1,5 @@
 from pyoos.utils.etree import etree
 from owslib.namespaces import Namespaces
-from owslib.util import testXMLValue
-import warnings
 
 ns = Namespaces()
 SML_NS = ns.get_versioned_namespace('sml', '1.0.1')
@@ -27,6 +25,7 @@ class IoosDescribeSensor(object):
         for ds_type, constructor in [('networkID', NetworkDS), ('stationID', StationDS), ('sensorID', SensorDS)]:
             if root.find(sml_str % ds_type) is not None:
                 return super(IoosDescribeSensor, cls).__new__(constructor)
-        # if we don't find the proper request, try to use DescribeSensor
+        # if we don't find the proper request from the IOOS definitions,
+        # try to adapt a generic DescribeSensor request to the dataset
         from pyoos.parsers.ioos.one.describe_sensor import GenericSensor
         return super(IoosDescribeSensor, cls).__new__(GenericSensor)

--- a/pyoos/parsers/ioos/one/describe_sensor.py
+++ b/pyoos/parsers/ioos/one/describe_sensor.py
@@ -7,36 +7,67 @@ from owslib.util import testXMLValue, testXMLAttribute, nspath_eval
 from pyoos.parsers.ioos.describe_sensor import IoosDescribeSensor
 
 from dateutil import parser
+from urlparse import urljoin
+from lxml import etree
+import warnings
 
 
 def get_namespaces():
     n = Namespaces()
     return n.get_namespaces(["sml101", "gml", "xlink", "swe101"])
+
 namespaces = get_namespaces()
+SWE_NS = namespaces['swe101']
+SML_NS = namespaces['sml101']
+ont = 'http://mmisw.org/ont/ioos/definition/'
 
 
 def nsp(path):
     return nspath_eval(path, namespaces)
 
 
-def get_named_by_definition(element_list, string_def):
-    try:
-        return next((st.value for st in element_list if st.definition == string_def))
-    except:
-        return None
-
-
 class DescribeSensor(IoosDescribeSensor):
-    def __init__(self, element):
-        super(DescribeSensor, self).__init__(element=element)
+    @classmethod
+    def get_named_by_definition(cls, element_list, string_def):
+        """Attempts to get an IOOS definition from a list of xml elements"""
+        try:
+            return next((st.value for st in element_list
+                        if st.definition == string_def))
+        except:
+            return None
 
+    def get_ioos_def(self, ident, elem_type, ont):
+        """Gets a definition given an identifier and where to search for it"""
+        if elem_type == 'identifier':
+            getter_fn = self.system.get_identifiers_by_name
+        elif elem_type == 'classifier':
+            getter_fn = self.system.get_classifiers_by_name
+        else:
+            raise ValueError("Unknown element type '{}'".format(elem_type))
+        return DescribeSensor.get_named_by_definition(getter_fn(ident),
+                                                      urljoin(ont, ident))
+
+    def __init__(self, element):
         """ Common things between all describe sensor requests """
-        self.ioos_version = "1.0"
+        if isinstance(element, str):
+            root = etree.fromstring(element)
+        else:
+            root = element
+
+        sml_str = ".//{{{0}}}identifier/{{{0}}}Term[@definition='http://mmisw.org/ont/ioos/definition/%s']".format(SML_NS)
+
+        # TODO: make this cleaner
+        if hasattr(root, 'getroot'):
+            root = root.getroot()
         self.system = SensorML(element).members[0]
 
-        self.shortName = get_named_by_definition(self.system.get_identifiers_by_name("shortName"), "http://mmisw.org/ont/ioos/definition/shortName")
-        self.longName  = get_named_by_definition(self.system.get_identifiers_by_name("longName"), "http://mmisw.org/ont/ioos/definition/longName")
-        self.keywords  = map(unicode, self.system.keywords)
+        self.ioos_version = testXMLValue(root.find(".//{%s}field[@name='ioosTemplateVersion']/{%s}Text/{%s}value" % (SWE_NS, SWE_NS, SWE_NS)))
+        if self.ioos_version != "1.0":
+            warnings.warn("Warning: Unsupported IOOS version (%s). Supported: [1.0]" % self.ioos_version)
+
+        self.shortName = self.get_ioos_def('shortName', 'identifier', ont)
+        self.longName = self.get_ioos_def('longName', 'identifier', ont)
+        self.keywords = map(unicode, self.system.keywords)
 
         # Location
         try:
@@ -49,34 +80,74 @@ class DescribeSensor(IoosDescribeSensor):
             timerange      = testXMLValue(self.system.get_capabilities_by_name("observationTimeRange")[0].find(".//" + nsp("swe101:TimeRange/swe101:value"))).split(" ")
             self.starting  = parser.parse(timerange[0])
             self.ending    = parser.parse(timerange[1])
-        except (AttributeError, TypeError, ValueError):
+        except (AttributeError, TypeError, ValueError, IndexError):
             self.starting  = None
             self.ending    = None
 
+class GenericSensor(DescribeSensor):
+    """A class used primarily for extracting data from non-IOOS SWE datasets"""
+    def __init__(self, element):
+        super(GenericSensor, self).__init__(element=element)
+        # try to find an identifier element of some sort
+        self.id = None
+        for ident in ['sensorId', 'stationId', 'networkId',
+                      'Sensor ID', 'Station ID', 'network ID']:
+            res = self.system.get_identifiers_by_name(ident)
+            if res:
+                self.id = res[0].value
+                break
+        self.variables = [comp.values()[0] for
+                          comp in self.system.components]
 
 class NetworkDS(DescribeSensor):
     def __init__(self, element):
         super(NetworkDS, self).__init__(element=element)
 
-        self.id             = get_named_by_definition(self.system.get_identifiers_by_name("networkID"), "http://mmisw.org/ont/ioos/definition/networkID")
+        self.id = self.get_ioos_def("networkID", "identifier", ont)
 
         # Verbose method of describing members.  Pull out each individual procedure
-        self.procedures = sorted(list(set([testXMLValue(comp.find(".//" + nsp("sml101:identifier[@name='stationID']/sml101:Term/sml101:value"))) for comp in self.system.components])))
+        # there is no 'lower-case' function in XPath 1, so we have to settle
+        # with this
+        sml_str = ".//{{{0}}}identifier/{{{0}}}Term[@definition='http://mmisw.org/ont/ioos/definition/%s']".format(SML_NS)
+        name_trans = """translate(@name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"""
+        stat_id_val = ".//sml101:identifier[{}='stationid']/sml101:Term/sml101:value".format(name_trans)
+        # TODO: maybe refactor to use ioos_get_def instead
+        def first_xpath_or_none(e):
+            res = e.xpath(stat_id_val, namespaces=namespaces)
+            if res:
+                return res[0]
+            else:
+                return None
+        self.procedures = sorted(list(set(
+                            [testXMLValue(first_xpath_or_none(comp))
+                            for comp in self.system.components])))
 
 
 class StationDS(DescribeSensor):
     def __init__(self, element):
         super(StationDS, self).__init__(element=element)
 
-        self.id            = get_named_by_definition(self.system.get_identifiers_by_name("stationID"), "http://mmisw.org/ont/ioos/definition/stationID")
-        self.platformType  = get_named_by_definition(self.system.get_classifiers_by_name("platformType"), "http://mmisw.org/ont/ioos/definition/platformType")
-
-        # Verbose method of describing members.  Pull out each individual variable definition
-        self.variables = sorted(list(set(itertools.chain.from_iterable([[testXMLAttribute(quan, "definition") for quan in comp.findall(".//" + nsp("swe101:Quantity"))] for comp in self.system.components]))))
+        self.id = self.get_ioos_def("stationID", "identifier", ont)
+        self.platformType = self.get_ioos_def("platformType", "classifier", ont)
+        # Verbose method of describing members.  Pull out each individual
+        # variable definition
+        self.variables = sorted(list(set(
+                                 itertools.chain.from_iterable(
+                                     [[testXMLAttribute(quan, "definition")
+                                      for quan in
+                                     comp.findall(".//" +
+                                                  nsp("swe101:Quantity"))]
+                                      for comp in self.system.components]))))
+        # if no variables were picked up, fall back to using original SML
+        # components instead
+        if not self.variables:
+            self.variables = sorted([comp.values()[0] for
+                                    comp in self.system.components])
 
 
 class SensorDS(DescribeSensor):
     def __init__(self, element):
         super(SensorDS, self).__init__(element=element)
 
-        self.id = get_named_by_definition(self.system.get_identifiers_by_name("sensorID"), "http://mmisw.org/ont/ioos/definition/sensorID")
+        self.id = self.get_ioos_def("sensorID", "identifier", ont)
+        self.platformType = self.get_ioos_def("platformType", "classifier", ont)


### PR DESCRIPTION
Handles index errors on time range causing them to fail gracefully.

Makes identifier attribute on station ids case insensitive when
gathering as part of a network.

Falls back to stock SensorML components when IOOS names not found.
Refactors some XML finding/ XPath functionality

Warn, do not automatically fail if IOOS SWE 1.0 milestone is not
implemented.  This makes it possible, for example, to create an IOOSDescribeSensor request and not fail.