### PR TITLE
Fix Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,23 @@
+sudo: false
 language: python
-python:
-  - "2.7"
+
+env:
+    - CONDA="python=2.7"
+    - CONDA="python=3.4"
+    - CONDA="python=3.5"
+
 before_install:
-  # Install miniconda
-  # -----------------
-  - export CONDA_BASE=http://repo.continuum.io/miniconda/Miniconda
-  - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
-      wget ${CONDA_BASE}-3.7.0-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget ${CONDA_BASE}3-3.7.0-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
+    - wget http://bit.ly/miniconda -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - conda update --all --yes
+    - conda config --add channels ioos -f
+    - travis_retry conda create --yes -n test $CONDA --file requirements.txt
+    - source activate test
+    - travis_retry conda install --yes pytest
 
-  # Create the basic testing environment
-  # ------------------------------------
-  - conda config --set always_yes yes --set changeps1 no
-  - conda config --set show_channel_urls True
-  - conda update --quiet conda
-  - ENV_NAME='test-environment'
-  - conda create --quiet -n $ENV_NAME python=$TRAVIS_PYTHON_VERSION
-  - source activate $ENV_NAME
+script:
+    - py.test -vv
 
-install:
-  # Customise the testing environment
-  # ---------------------------------
-  - conda install --channel https://conda.binstar.org/rsignell --file requirements.txt
-  - conda install pytest
-script: py.test -vv
 notifications:
     flowdock: 2dd835dfbdbc64986ba043fffa654836,1d5af475ae38ec1d874c752c23558d2d
-

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,23 @@
 from __future__ import with_statement
+import os
 import sys
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-from pyoos import __version__
+def extract_version(module='pyoos'):
+    version = None
+    fdir = os.path.dirname(__file__)
+    fnme = os.path.join(fdir, module, '__init__.py')
+    with open(fnme) as fd:
+        for line in fd:
+            if (line.startswith('__version__')):
+                _, version = line.split('=')
+                # Remove quotation characters.
+                version = version.strip()[1:-1]
+                break
+    return version
+
 
 def readme():
     with open('README.md') as f:
@@ -24,7 +37,7 @@ class PyTest(TestCommand):
 
 setup(
     name                = "pyoos",
-    version             = __version__,
+    version             = extract_version(),
     description         = "A Python library for collecting Met/Ocean observations",
     long_description    = readme(),
     license             = 'GPLv3',

--- a/tests/collectors/test_coops_sos.py
+++ b/tests/collectors/test_coops_sos.py
@@ -18,7 +18,7 @@ class CoopsSosTest(unittest.TestCase):
         assert self.c.server.identification.service == 'OGC:SOS'
         assert self.c.server.identification.version == '1.0.0'
         assert self.c.server.identification.abstract == 'NOAA.NOS.CO-OPS Sensor Observation Service (SOS) Server'
-        assert self.c.server.identification.keywords == ['Air Temperature', 'Barometric Pressure', 'Conductivity', 'Currents', 'Datums', 'Rain Fall', 'Relative Humidity', 'Harmonic Constituents', 'Salinity', 'Visibility', 'Water Level', 'Water Level Predictions', 'Water Temperature', 'Winds']  # noqa
+        assert self.c.server.identification.keywords == ['Air Temperature', 'Barometric Pressure', 'Conductivity', 'Currents', 'Datum', 'Harmonic Constituents', 'Rain Fall', 'Relative Humidity', 'Salinity', 'Visibility', 'Water Level', 'Water Level Predictions', 'Water Temperature', 'Winds']
         assert self.c.server.identification.fees == 'NONE'
         assert self.c.server.identification.accessconstraints == 'NONE'
 

--- a/tests/collectors/test_coops_sos.py
+++ b/tests/collectors/test_coops_sos.py
@@ -18,20 +18,20 @@ class CoopsSosTest(unittest.TestCase):
         assert self.c.server.identification.service == 'OGC:SOS'
         assert self.c.server.identification.version == '1.0.0'
         assert self.c.server.identification.abstract == 'NOAA.NOS.CO-OPS Sensor Observation Service (SOS) Server'
-        assert self.c.server.identification.keywords == ['Air Temperature', 'Barometric Pressure', 'Conductivity', 'Currents', 'Datums', 'Rain Fall', 'Relative Humidity', 'Harmonic Constituents', 'Salinity', 'Visibility', 'Water Level', 'Water Level Predictions', 'Water Temperature', 'Winds']
+        assert self.c.server.identification.keywords == ['Air Temperature', 'Barometric Pressure', 'Conductivity', 'Currents', 'Datums', 'Rain Fall', 'Relative Humidity', 'Harmonic Constituents', 'Salinity', 'Visibility', 'Water Level', 'Water Level Predictions', 'Water Temperature', 'Winds']  # noqa
         assert self.c.server.identification.fees == 'NONE'
         assert self.c.server.identification.accessconstraints == 'NONE'
 
     def test_coops_describe_sensor(self):
         self.c.features = ['8454000']
-        response = self.c.metadata(output_format='text/xml;subtype="sensorML/1.0.1"')
+        response = self.c.metadata(output_format='text/xml;subtype="sensorML/1.0.1/profiles/ioos_sos/1.0"')
         assert isinstance(response[0], SensorML)
 
     def test_raw_coops_get_observation(self):
         self.c.start_time   = datetime.strptime("2012-10-01", "%Y-%m-%d")
         self.c.end_time     = datetime.strptime("2012-10-02", "%Y-%m-%d")
         self.c.features     = ['8454000']
-        self.c.variables    = ['http://mmisw.org/ont/cf/parameter/water_surface_height_above_reference_datum']
+        self.c.variables    = ['http://mmisw.org/ont/cf/parameter/water_surface_height_above_reference_datum']  # noqa
 
         response = self.c.raw(responseFormat="text/csv")
         assert isinstance(response, basestring)

--- a/tests/collectors/test_usgs.py
+++ b/tests/collectors/test_usgs.py
@@ -43,8 +43,10 @@ class USGSTest(unittest.TestCase):
         self.c.filter(state="ri")
         collection = self.c.collect()
 
-        # Returns 41 stations
-        assert len(collection.elements) == 41
+        # Returns 43 stations.
+        # FIXME: This is a flaky test.  The station number changed from 41,
+        # to 42 and now 43.
+        assert len(collection.elements) == 43
 
         station = collection.elements[0]
         assert station.name == "TEN MILE R., PAWTUCKET AVE. AT E. PROVIDENCE, RI"


### PR DESCRIPTION
In order to investigate https://github.com/ioos/secoora/issues/225 I am coming back to pyoos a lot, so we need to get Travis-CI back online.

- `pyoos` builds on Python 3, but is far from py3k compliant.  There is a significant amount of work to do.  I am deleting the pyoos python3 binaries from the ioos channel.
- Some of the failures we are seeing are in the Python 2.7 are similar to what I am observing in my SECOORA notebooks.  I will keep investigating what changed.

Ping @kwilcox, @rsignell-usgs, and @vembus.