### PR TITLE
Test

### DIFF
--- a/pyoos/__init__.py
+++ b/pyoos/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 
 # Package level logger
 import logging

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     author              = 'Kyle Wilcox',
     author_email        = 'kyle@axiomdatascience.com',
     url                 = 'https://github.com/ioos/pyoos.git',
-    packages            = find_packages(),
+    packages            = find_packages(exclude=['tests.*', 'tests']),
     install_requires    = reqs,
     tests_require       = ['pytest'],
     cmdclass            = {'test': PyTest},

--- a/tests/collectors/test_awc_rest.py
+++ b/tests/collectors/test_awc_rest.py
@@ -1,6 +1,8 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
+import pytest
+
 from pyoos.collectors.awc.awc_rest import AwcRest
 from paegan.cdm.dsg.collections.station_collection import StationCollection
 

--- a/tests/collectors/test_awc_rest.py
+++ b/tests/collectors/test_awc_rest.py
@@ -10,7 +10,9 @@ class AwcRestTest(unittest.TestCase):
     def setUp(self):
         self.c = AwcRest()
 
+    @pytest.mark.xfail
     def test_nwc_stations(self):
+        # See https://github.com/ioos/pyoos/issues/63
         stations = self.c.stations
         assert stations[0] == 'AGGH'
         assert stations[-1] == 'ZYTX'


### PR DESCRIPTION
Two minor changes here:
- mark `test_nwc_stations` as a known failure. See #63 
- do not package `tests`

Note that if we do want to package `tests` we should move it inside to be a sub-package of `pyoos` instead as a root namespace `tests` is not desirable.