### PR TITLE
Fixes #63

### DIFF
--- a/pyoos/collectors/awc/awc_rest.py
+++ b/pyoos/collectors/awc/awc_rest.py
@@ -8,15 +8,16 @@ import requests
 class AwcRest(Collector):
     def __init__(self, **kwargs):
         super(AwcRest, self).__init__()
-        self.stations_url = 'http://weather.noaa.gov/data/nsd_cccc.txt'
+        self.stations_url = 'https://www.aviationweather.gov/docs/metar/stations.txt'
         self.data_url     = 'http://www.aviationweather.gov/adds/dataserver_current/httpparam'
 
     def get_stations(self):
         if self._features is None:
             r = requests.get(self.stations_url)
-            self._stations = [line.split(';')[0] for line in r.text.split('\n')]
-            if self._stations[-1] == '':
-                self._stations.pop()
+            # Arghhhh Fortran-like fixed format!!!
+            _stations = [line[20:24] for line in r.text.split('\n')
+                         if len(line) == 83 and not line.startswith('!')]
+            self._stations = sorted(filter(lambda code: code.strip(), _stations))
             self._features = self._stations
         return self._features
 

--- a/tests/collectors/test_awc_rest.py
+++ b/tests/collectors/test_awc_rest.py
@@ -12,12 +12,10 @@ class AwcRestTest(unittest.TestCase):
     def setUp(self):
         self.c = AwcRest()
 
-    @pytest.mark.xfail
     def test_nwc_stations(self):
-        # See https://github.com/ioos/pyoos/issues/63
         stations = self.c.stations
-        assert stations[0] == 'AGGH'
-        assert stations[-1] == 'ZYTX'
+        assert stations[0] == 'AAAD'
+        assert stations[-1] == 'ZYYY'
 
     def test_bbox_filter_raw(self):
         self.c.filter(bbox=(-80, 30, -60, 50))


### PR DESCRIPTION
@lukecampbell I am not sure if I am getting the right field from https://www.aviationweather.gov/docs/metar/stations.txt

Based on the tests I assume it should be `ICAO = 4-character international id`. Also, I am not completely certain that all we need to parse is that list. Anyways, I believe this is better than removing it for now.