### PR TITLE
Add 'metadata_plus_exceptions' function to return SensorML, plus ServiceExceptions

### DIFF
--- a/pyoos/collectors/ioos/swe_sos.py
+++ b/pyoos/collectors/ioos/swe_sos.py
@@ -40,8 +40,9 @@ class IoosSweSos(Collector):
         """
         Gets SensorML objects for all procedures in your filtered features.
 
-        Include any errors returned from SOS DescribeSensor request in a second return value
-        dictionary object
+        Return two dictionaries for service responses keyed by 'feature':
+            responses: values are SOS DescribeSensor response text
+            response_failures: values are exception text content furnished from ServiceException, ExceptionReport
 
         You should override the default output_format for servers that do not
         respond properly.
@@ -50,7 +51,7 @@ class IoosSweSos(Collector):
         if output_format is None:
             output_format = 'text/xml; subtype="sensorML/1.0.1/profiles/ioos_sos/1.0"'
 
-        responses = []
+        responses = {}
         response_failures = {}
         if self.features is not None:
             for feature in self.features:
@@ -58,7 +59,7 @@ class IoosSweSos(Collector):
                 ds_kwargs.update({'outputFormat': output_format,
                                   'procedure'   : callback(feature)})
                 try:
-                    responses.append(SensorML(self.server.describe_sensor(**ds_kwargs)))
+                    responses[feature] = (SensorML(self.server.describe_sensor(**ds_kwargs)))
                 except (ServiceException, ExceptionReport) as e:
                     response_failures[feature] = str(e)
 

--- a/pyoos/collectors/ioos/swe_sos.py
+++ b/pyoos/collectors/ioos/swe_sos.py
@@ -56,7 +56,6 @@ class IoosSweSos(Collector):
                 ds_kwargs = kwargs.copy()
                 ds_kwargs.update({'outputFormat': output_format,
                                   'procedure'   : callback(feature)})
-                print("swe_sos.py metadata: {feature}".format(feature=feature))
                 try:
                     responses.append(SensorML(self.server.describe_sensor(**ds_kwargs)))
                 except ServiceException as e:

--- a/pyoos/collectors/ioos/swe_sos.py
+++ b/pyoos/collectors/ioos/swe_sos.py
@@ -3,6 +3,7 @@ from six import string_types
 
 from pyoos.collectors.collector import Collector
 from pyoos.parsers.ioos.get_observation import IoosGetObservation
+from owslib.ows import ExceptionReport
 from owslib.sos import SensorObservationService as Sos
 from owslib.swe.sensor.sml import SensorML
 from owslib.util import ServiceException
@@ -58,7 +59,7 @@ class IoosSweSos(Collector):
                                   'procedure'   : callback(feature)})
                 try:
                     responses.append(SensorML(self.server.describe_sensor(**ds_kwargs)))
-                except ServiceException as e:
+                except (ServiceException, ExceptionReport) as e:
                     response_failures[feature] = str(e)
 
         return (responses, response_failures)

--- a/tests/collectors/test_ioos_swe_sos.py
+++ b/tests/collectors/test_ioos_swe_sos.py
@@ -1,0 +1,49 @@
+from __future__ import (absolute_import, division, print_function)
+from six import string_types
+
+import unittest
+import csv
+import io
+from datetime import datetime
+
+from owslib.swe.sensor.sml import SensorML
+
+from pyoos.collectors.ioos.swe_sos import IoosSweSos
+
+
+class IoosSweSosTest(unittest.TestCase):
+
+    def setUp(self):
+        # we have to pick SOS to test against, NANOOS it is:
+        self.c = IoosSweSos("http://data.nanoos.org/52nsos/sos/kvp")
+        # self.c.features = [urn.name for urn in self.c.server.offerings]
+
+
+    def test_server_id(self):
+        assert self.c.server.identification.title == "NANOOS Sensor Observation Service (SOS), a 52North IOOS SOS server"
+        assert self.c.server.identification.service == 'OGC:SOS'
+        assert self.c.server.identification.version == '1.0.0'
+        assert self.c.server.identification.fees == 'NONE'
+        assert self.c.server.identification.accessconstraints == 'NONE'
+
+    def test_metdata(self):
+        self.c.features = ['urn:ioos:station:nanoos:apl_nemo']
+        response = self.c.metadata(output_format='text/xml; subtype="sensorML/1.0.1/profiles/ioos_sos/1.0"')
+        assert isinstance(response, list)
+        assert isinstance(response[0], SensorML)
+
+    def test_metadata_plus_exceptions(self):
+        self.c.features = ['urn:ioos:station:nanoos:apl_nemo']
+        response, failures = self.c.metadata_plus_exceptions(output_format='text/xml; subtype="sensorML/1.0.1/profiles/ioos_sos/1.0"')
+        assert isinstance(response, dict)
+        assert isinstance(failures, dict)
+        assert isinstance(response[self.c.features[0]], SensorML)
+
+#    def test_raw_get_observation(self):
+#        self.c.start_time   = datetime.strptime("2014-10-23", "%Y-%m-%d")
+#        self.c.end_time     = datetime.strptime("2014-10-24", "%Y-%m-%d")
+#        self.c.features     = ['urn:ioos:station:nanoos:cmop_saturn08']
+#        self.c.variables    = ['sea_water_temperature']
+
+#        response = self.c.raw(responseFormat="text/xml;+subtype=\"om/1.0.0/profiles/ioos_sos/1.0\"").decode()
+#        assert isinstance(response, string_types)


### PR DESCRIPTION
Some SOS services do not always successfully return SensorML for all procedures, breaking 'metadata' function.