### PR TITLE
bump version

### DIFF
--- a/pyoos/__init__.py
+++ b/pyoos/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 
 # Package level logger
 import logging


### PR DESCRIPTION
Self-merging this since it only bumps the build number for a new release with PRs #75 and #78.